### PR TITLE
refactor: remove DependencyType.SOFT

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/patcher/Patcher.kt
@@ -11,7 +11,6 @@ import app.revanced.patcher.patch.Patch
 import app.revanced.patcher.patch.PatchResult
 import app.revanced.patcher.patch.PatchResultError
 import app.revanced.patcher.patch.PatchResultSuccess
-import app.revanced.patcher.patch.annotations.DependencyType
 import app.revanced.patcher.patch.impl.BytecodePatch
 import app.revanced.patcher.patch.impl.ResourcePatch
 import app.revanced.patcher.util.ListBackedSet
@@ -265,11 +264,6 @@ class Patcher(private val options: PatcherOptions) {
         // recursively apply all dependency patches
         patch.dependencies.forEach {
             val dependency = it.patch.java
-            if ( // soft dependencies must be included manually.
-                it.type == DependencyType.SOFT && !data.patches.any { p ->
-                    p.patchName == dependency.patchName
-                }
-            ) return@forEach
 
             val result = applyPatch(dependency, appliedPatches)
             if (result.isSuccess()) return@forEach

--- a/src/main/kotlin/app/revanced/patcher/patch/annotations/PatchAnnotation.kt
+++ b/src/main/kotlin/app/revanced/patcher/patch/annotations/PatchAnnotation.kt
@@ -43,11 +43,5 @@ enum class DependencyType {
     /**
      * Enforces that the dependency is applied, even if it was not selected.
      */
-    HARD,
-
-    /**
-     * Applies the dependency only if it was selected.
-     */
-    @Deprecated("Will be removed when Patch Options is implemented.")
-    SOFT
+    HARD
 }

--- a/src/test/kotlin/app/revanced/patcher/usage/bytecode/ExampleBytecodePatch.kt
+++ b/src/test/kotlin/app/revanced/patcher/usage/bytecode/ExampleBytecodePatch.kt
@@ -38,7 +38,7 @@ import org.jf.dexlib2.util.Preconditions
 @Description("Example demonstration of a bytecode patch.")
 @ExampleResourceCompatibility
 @Version("0.0.1")
-@DependsOn(ExampleBytecodePatch::class, DependencyType.SOFT)
+@DependsOn(ExampleBytecodePatch::class, DependencyType.HARD)
 class ExampleBytecodePatch : BytecodePatch(listOf(ExampleFingerprint)) {
     // This function will be executed by the patcher.
     // You can treat it as a constructor


### PR DESCRIPTION
`DependencyType.SOFT` has now been removed after it was deprecated. There is no direct replacement for this.

Please look into Patch Options instead, which supersedes this:
https://github.com/revanced/revanced-patcher/blob/711b8a25a7c2842270b06e831ee7844a2c86d7c2/src/test/kotlin/app/revanced/patcher/usage/bytecode/ExampleBytecodePatch.kt#L167-L180