### PR TITLE
chore: copy the semantic version comparator to the patcher

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/util/patch/SemanticVersion.kt
+++ b/src/main/kotlin/app/revanced/patcher/util/patch/SemanticVersion.kt
@@ -1,0 +1,24 @@
+package app.revanced.patcher.util.patch
+
+data class SemanticVersion(val major: Int, val minor: Int, val patch: Int) {
+    companion object {
+        fun fromString(version: String): SemanticVersion {
+            var parts = version.split(".")
+
+            if (parts.count() != 3) throw IllegalArgumentException("Invalid semantic version")
+
+            val versionNumbers = parts.map { it.toInt() }
+            return SemanticVersion(versionNumbers[0], versionNumbers[1], versionNumbers[2])
+        }
+    }
+
+    override fun toString(): String = "$major.$minor.$patch"
+}
+
+object SemanticVersionComparator : Comparator<SemanticVersion> {
+    override fun compare(a: SemanticVersion, b: SemanticVersion): Int = when {
+        a.major != b.major -> a.major - b.major
+        a.minor != b.minor -> a.minor - b.minor
+        else -> a.patch - b.patch
+    }
+}


### PR DESCRIPTION
Looking at #72, I figured it would be best to move the semantic version comparator to the patcher. It can then be imported in the cli as well revanced-patches.