### PR TITLE
fix: publicize types when merging files if necessary

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/util/TypeUtil.kt
+++ b/src/main/kotlin/app/revanced/patcher/util/TypeUtil.kt
@@ -1,0 +1,19 @@
+package app.revanced.patcher.util
+
+import app.revanced.patcher.data.BytecodeContext
+import app.revanced.patcher.util.proxy.mutableTypes.MutableClass
+
+object TypeUtil {
+    /**
+     * traverse the class hierarchy starting from the given root class
+     *
+     * @param targetClass the class to start traversing the class hierarchy from
+     * @param callback function that is called for every class in the hierarchy
+     */
+    fun BytecodeContext.traverseClassHierarchy(targetClass: MutableClass, callback: MutableClass.() -> Unit) {
+        callback(targetClass)
+        this.findClass(targetClass.superclass ?: return)?.mutableClass?.let {
+            traverseClassHierarchy(it, callback)
+        }
+    }
+}


### PR DESCRIPTION
This PR makes classes public, if public missing methods or fields are to be merged into them. This is necessary because ART apparently requires the class to be public, regardless of the access of the methods and fields. The issue this PR fixes can be reproduced with the `block-embedded-ads` patch for Twitch. The integrations class contains public methods, and therefore the class is also public. Because these methods do not exist in Twitch, it was necessary to merge them, requiring the class to be public as well. Superclasses are considered in this PR recursively, as well.