### PR TITLE
Update Gradle wrapper to 8.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ gradle-app.setting
 
 # Dependency directories
 node_modules/
+
+# Gradle props, to avoid sharing the gpr key
+gradle.properties

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
And also ignore gradle.properties, we don't want to share the github token.

This change is necessary to compile the project with Java 19. Gradle 8 doesn't introduce any breaking changes to the workflow as far as I've tested