### PR TITLE
fix: compare method fingerprint parameter order

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/extensions/Extensions.kt
+++ b/src/main/kotlin/app/revanced/patcher/extensions/Extensions.kt
@@ -224,13 +224,12 @@ internal fun Method.cloneMutable(registerCount: Int = 0) = clone(registerCount).
 internal fun parametersEqual(
     parameters1: Iterable<CharSequence>, parameters2: Iterable<CharSequence>
 ): Boolean {
-    return parameters1.count() == parameters2.count() && parameters1.all { parameter ->
-        parameters2.any {
-            it.startsWith(
-                parameter
-            )
-        }
+    if (parameters1.count() != parameters2.count()) return false
+    val iterator1 = parameters1.iterator()
+    parameters2.forEach {
+        if (!it.startsWith(iterator1.next())) return false
     }
+    return true
 }
 
 internal val nullOutputStream = object : OutputStream() {

--- a/src/main/kotlin/app/revanced/patcher/extensions/Extensions.kt
+++ b/src/main/kotlin/app/revanced/patcher/extensions/Extensions.kt
@@ -220,7 +220,6 @@ private fun replaceOffset(
  */
 internal fun Method.cloneMutable(registerCount: Int = 0) = clone(registerCount).toMutable()
 
-// FIXME: also check the order of parameters as different order equals different method overload
 internal fun parametersEqual(
     parameters1: Iterable<CharSequence>, parameters2: Iterable<CharSequence>
 ): Boolean {


### PR DESCRIPTION
Implemented TODO

Provides stronger matching and gives a slight speed up (around 2-3 seconds improvement when patching YouTube on a laptop), but this also means some existing patches will need updating because the method signature parameters are not the correct order.

edit: all YouTube patches function correctly, also all 'universal' patches work ok as well.
