### PR TITLE
fix: null pointer exception if fingerprint specified a non existent signature

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/fingerprint/method/impl/MethodFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patcher/fingerprint/method/impl/MethodFingerprint.kt
@@ -207,7 +207,7 @@ abstract class MethodFingerprint(
                     append(returnTypeValue.first())
                     if (parameters != null) appendParameters(parameters)
                 }
-                return methodSignatureLookupMap[key]!!
+                return methodSignatureLookupMap[key] ?: return emptyList()
             }
 
             /**


### PR DESCRIPTION
fix for NPE if a fingerprint specifies access/return/parameters that do not match any methods in the target app.
