### PR TITLE
fix: clear method lookup maps

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/patcher/Patcher.kt
@@ -389,6 +389,8 @@ class Patcher(private val options: PatcherOptions) {
                         if (stopOnError) return@sequence
                     }
                 }
+
+            MethodFingerprint.clearFingerprintResolutionLookupMaps()
         }
     }
 

--- a/src/main/kotlin/app/revanced/patcher/fingerprint/method/impl/MethodFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patcher/fingerprint/method/impl/MethodFingerprint.kt
@@ -139,6 +139,15 @@ abstract class MethodFingerprint(
         }
 
         /**
+         * Clears the internal lookup maps created in [initializeFingerprintResolutionLookupMaps]
+         */
+        internal fun clearFingerprintResolutionLookupMaps() {
+            methods.clear()
+            methodSignatureLookupMap.clear()
+            methodStringsLookupMap.clear()
+        }
+
+        /**
          * Resolve a list of [MethodFingerprint] using the lookup map built by [initializeFingerprintResolutionLookupMaps].
          *
          * [MethodFingerprint] resolution is fast, but if many are present they can consume a noticeable


### PR DESCRIPTION
Since the patcher stays in memory, patching in Manager multiple times (without restarting the app) always fails on the second patch.   The lookup maps to be cleared after patching finishes.

This fix should be pushed out now, and Manager needs another dependency update and release.

![manager multiple patch error](https://github.com/revanced/revanced-patcher/assets/118716522/d3f7ea0d-8ec0-4828-b519-b846c45d8b65)

