### PR TITLE
fix: clear `FingerprintResolutionLookupMaps` before patching

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/patcher/Patcher.kt
@@ -77,6 +77,7 @@ class Patcher(private val options: PatcherOptions) {
             this@integrations.callback = callback
         }
     }
+
     /**
      * Save the patched dex file.
      */

--- a/src/main/kotlin/app/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/patcher/Patcher.kt
@@ -78,6 +78,10 @@ class Patcher(private val options: PatcherOptions) {
         }
     }
 
+    fun clearMaps() {
+        MethodFingerprint.clearFingerprintResolutionLookupMaps()
+    }
+    
     /**
      * Save the patched dex file.
      */

--- a/src/main/kotlin/app/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/patcher/Patcher.kt
@@ -77,7 +77,6 @@ class Patcher(private val options: PatcherOptions) {
             this@integrations.callback = callback
         }
     }
-    
     /**
      * Save the patched dex file.
      */

--- a/src/main/kotlin/app/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/patcher/Patcher.kt
@@ -77,10 +77,6 @@ class Patcher(private val options: PatcherOptions) {
             this@integrations.callback = callback
         }
     }
-
-    fun clearMaps() {
-        MethodFingerprint.clearFingerprintResolutionLookupMaps()
-    }
     
     /**
      * Save the patched dex file.

--- a/src/main/kotlin/app/revanced/patcher/fingerprint/method/impl/MethodFingerprint.kt
+++ b/src/main/kotlin/app/revanced/patcher/fingerprint/method/impl/MethodFingerprint.kt
@@ -99,7 +99,7 @@ abstract class MethodFingerprint(
                 methodClassPairs!!.add(methodClassPair)
             }
 
-            if (methods.isNotEmpty()) throw PatchResultError("Map already initialized")
+            if (methods.isNotEmpty()) MethodFingerprint.clearFingerprintResolutionLookupMaps()
 
             context.classes.classes.forEach { classDef ->
                 classDef.methods.forEach { method ->


### PR DESCRIPTION
Right now, if we abort the patching process after merging integrations, we need to restart the app to start another patching process.

This PR aims to clear the maps from previous patching session so that new session can be started at any time.