### PR TITLE
fix: Fix SMALI compilation on devices with RTL language

### DIFF
--- a/revanced-patcher/src/main/kotlin/app/revanced/patcher/patch/Patch.kt
+++ b/revanced-patcher/src/main/kotlin/app/revanced/patcher/patch/Patch.kt
@@ -1,4 +1,4 @@
-@file:Suppress("MemberVisibilityCanBePrivate", "UNUSED_PARAMETER")
+@file:Suppress("MemberVisibilityCanBePrivate")
 
 package app.revanced.patcher.patch
 

--- a/revanced-patcher/src/main/kotlin/app/revanced/patcher/patch/PatchResult.kt
+++ b/revanced-patcher/src/main/kotlin/app/revanced/patcher/patch/PatchResult.kt
@@ -6,5 +6,4 @@ package app.revanced.patcher.patch
  * @param patch The [Patch] that was executed.
  * @param exception The [PatchException] thrown, if any.
  */
-@Suppress("MemberVisibilityCanBePrivate")
 class PatchResult internal constructor(val patch: Patch<*>, val exception: PatchException? = null)

--- a/revanced-patcher/src/main/kotlin/app/revanced/patcher/util/smali/InlineSmaliCompiler.kt
+++ b/revanced-patcher/src/main/kotlin/app/revanced/patcher/util/smali/InlineSmaliCompiler.kt
@@ -13,6 +13,7 @@ import com.android.tools.smali.smali.smaliFlexLexer
 import com.android.tools.smali.smali.smaliParser
 import com.android.tools.smali.smali.smaliTreeWalker
 import java.io.InputStreamReader
+import java.util.Locale
 
 private const val METHOD_TEMPLATE = """
     .class LInlineCompiler;
@@ -33,7 +34,7 @@ class InlineSmaliCompiler {
         fun compile(
             instructions: String, parameters: String, registers: Int, forStaticMethod: Boolean
         ): List<BuilderInstruction> {
-            val input = METHOD_TEMPLATE.format(
+            val input = METHOD_TEMPLATE.format(Locale.ENGLISH,
                 if (forStaticMethod) {
                     "static"
                 } else {


### PR DESCRIPTION
If the device uses a RTL language then patching fails with a syntax error:

```
Caused by: java.lang.IllegalStateException: Encountered 1 parser syntax errors and 0 lexer syntax errors!
	at app.revanced.patcher.util.smali.InlineSmaliCompiler$Companion.compile(InlineSmaliCompiler.kt:49)
	at app.revanced.patcher.util.smali.InlineSmaliCompilerKt.toInstructions(InlineSmaliCompiler.kt:72)
	at app.revanced.patcher.util.smali.InlineSmaliCompilerKt.toInstruction(InlineSmaliCompiler.kt:84)
	at app.revanced.patcher.extensions.InstructionExtensions.addInstruction(InstructionExtensions.kt:92)
	at app.revanced.patches.shared.integrations.AbstractIntegrationsPatch$IntegrationsFingerprint.invoke(AbstractIntegrationsPatch.kt:43)
	at app.revanced.patches.shared.integrations.AbstractIntegrationsPatch.execute(AbstractIntegrationsPatch.kt:61)
	at app.revanced.patches.shared.integrations.AbstractIntegrationsPatch.execute(AbstractIntegrationsPatch.kt:13)

```
This bug can be reproduced by specifying a RTL language:
`java -Duser.language=ar -jar revanced-cli-*-all.jar ...`

This bug affects both CLI and Manger.

The fix is to format all strings using a LTR locale.