### PR TITLE
docs: tipo resource using rawResource

### DIFF
--- a/docs/2_patches_intro.md
+++ b/docs/2_patches_intro.md
@@ -94,21 +94,21 @@ Example of patches:
 
 ```kt
 @Surpress("unused")
-val bytecodePatch = BytecodePatch {
+val bytecodePatch = bytecodePatch {
     execute { 
         // TODO
     }
 }
 
 @Surpress("unused")
-val rawResourcePatch = RawResourcePatch {
+val rawResourcePatch = rawResourcePatch {
     execute { 
         // TODO
     }
 }
 
 @Surpress("unused")
-val resourcePatch = ResourcePatch {
+val resourcePatch = resourcePatch {
     execute { 
         // TODO
     }

--- a/docs/2_patches_intro.md
+++ b/docs/2_patches_intro.md
@@ -94,21 +94,21 @@ Example of patches:
 
 ```kt
 @Surpress("unused")
-val bytecodePatch = bytecodePatch {
+val bytecodePatch = BytecodePatch {
     execute { 
         // TODO
     }
 }
 
 @Surpress("unused")
-val rawResourcePatch = rawResourcePatch {
+val rawResourcePatch = RawResourcePatch {
     execute { 
         // TODO
     }
 }
 
 @Surpress("unused")
-val resourcePatch = rawResourcePatch {
+val resourcePatch = ResourcePatch {
     execute { 
         // TODO
     }


### PR DESCRIPTION
The `resourcePatch` value was constructed from the `RawResourcePatch` which is a bit misleading. Also use the 1st letter uppercase convention from Kotlin.