### PR TITLE
fix: Make it work on Android 12 and lower by using existing APIs

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/revanced/patcher/patch/BytecodePatchContext.kt
@@ -71,7 +71,7 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
             if (patch !is BytecodePatch) return@forEachRecursively
 
             patch.extension?.use { extensionStream ->
-                RawDexIO.readRawDexFile(extensionStream, 1024, null).classes.forEach { classDef ->
+                RawDexIO.readRawDexFile(extensionStream, 0, null).classes.forEach { classDef ->
                     val existingClass = classesByType[classDef.type] ?: run {
                         logger.fine("Adding class \"$classDef\"")
 

--- a/src/main/kotlin/app/revanced/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/revanced/patcher/patch/BytecodePatchContext.kt
@@ -93,8 +93,6 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
                         classes += mergedClass
                     }
                 }
-
-                patch.extension.close()
             }
         }
     }


### PR DESCRIPTION
Fixes patching failure when using Manger and Android 12 or lower.

All other patcher code seems to compile just fine.

Changing the project Android SDK to 8.0 correctly detects the issue.  I'm not sure if Android 8.0 can be set in a gradle config file or somewhere else, as changing the project in Android Studio does not change any project files.