### PR TITLE
fix: Merge extension only when patch executes

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/Patcher.kt
+++ b/src/main/kotlin/app/revanced/patcher/Patcher.kt
@@ -91,19 +91,15 @@ class Patcher(private val config: PatcherConfig) : Closeable {
             }.also { executedPatches[this] = it }
         }
 
-        // Prevent from decoding the app manifest twice if it is not needed.
+        // Prevent decoding the app manifest twice if it is not needed.
         if (config.resourceMode != ResourcePatchContext.ResourceMode.NONE) {
             context.resourceContext.decodeResources(config.resourceMode)
         }
 
-        logger.info("Merging extensions")
+        logger.info("Initializing lookup maps")
 
-        with(context.bytecodeContext) {
-            context.executablePatches.mergeExtensions()
-
-            // Initialize lookup maps.
-           lookupMaps
-        }
+        // Accessing the lazy lookup maps to initialize them.
+        context.bytecodeContext.lookupMaps
 
         logger.info("Executing patches")
 

--- a/src/main/kotlin/app/revanced/patcher/patch/Patch.kt
+++ b/src/main/kotlin/app/revanced/patcher/patch/Patch.kt
@@ -158,7 +158,13 @@ class BytecodePatch internal constructor(
     finalizeBlock,
 ) {
     override fun execute(context: PatcherContext) = with(context.bytecodeContext) {
-        fingerprints.forEach { it.match(this) }
+        with(context.bytecodeContext) {
+            mergeExtension()
+        }
+
+        fingerprints.forEach {
+            it.match(this)
+        }
 
         execute(this)
     }

--- a/src/test/kotlin/app/revanced/patcher/PatcherTest.kt
+++ b/src/test/kotlin/app/revanced/patcher/PatcherTest.kt
@@ -195,7 +195,7 @@ internal object PatcherTest {
     private operator fun Set<Patch<*>>.invoke(): List<PatchResult> {
         every { patcher.context.executablePatches } returns toMutableSet()
         every { patcher.context.bytecodeContext.lookupMaps } returns LookupMaps(patcher.context.bytecodeContext.classes)
-        every { with(patcher.context.bytecodeContext) { any<Set<Patch<*>>>().mergeExtensions() } } just runs
+        every { with(patcher.context.bytecodeContext) { any<BytecodePatch>().mergeExtension() } } just runs
 
         return runBlocking { patcher().toList() }
     }


### PR DESCRIPTION
This PR changes how extensions are merged. Before, all extensions were merged unconditionally regardless of whether a patch succeeded. This was done to reduce memory overhead since the lookup map for the merge could be removed after all extensions were merged. Now, an extension of a patch is merged right before the patch is executed. This requires the lookup map to be kept in memory as long as the patches are executing. This should not be much of a problem. The maps are cleared after all patches were executed