### PR TITLE
fix: Add back missing log by naming logger correctly

### DIFF
--- a/src/main/kotlin/app/revanced/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/revanced/patcher/patch/BytecodePatchContext.kt
@@ -34,7 +34,7 @@ import java.util.logging.Logger
 class BytecodePatchContext internal constructor(private val config: PatcherConfig) :
     PatchContext<Set<PatcherResult.PatchedDexFile>>,
     Closeable {
-    private val logger = Logger.getLogger(this::javaClass.name)
+    private val logger = Logger.getLogger(this::class.java.name)
 
     /**
      * [Opcodes] of the supplied [PatcherConfig.apkFile].


### PR DESCRIPTION
`this::javaClass.name` returns a wrong name

```kt
println(this::javaClass.name)
// javaClass

println(this::class.java.name)
// app.revanced.patcher.patch.BytecodePatchContext
```

And the logger is configured to output logs whose loggerName starts with "app.revanced".
As a result, log messages in `BytecodePatchContext` was not printed on both CLI and Manager.
This PR fixes this problem.