### PR TITLE
fix: Replace dex input streams with file references

### DIFF
--- a/api/revanced-patcher.api
+++ b/api/revanced-patcher.api
@@ -171,9 +171,12 @@ public final class app/revanced/patcher/patch/BytecodePatchContext : app/revance
 public final class app/revanced/patcher/patch/Option {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefault ()Ljava/lang/Object;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getKey ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
 	public final fun getRequired ()Z
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun getType ()Lkotlin/reflect/KType;

--- a/api/revanced-patcher.api
+++ b/api/revanced-patcher.api
@@ -88,8 +88,8 @@ public final class app/revanced/patcher/PatcherResult {
 }
 
 public final class app/revanced/patcher/PatcherResult$PatchedDexFile {
+	public final fun getFile ()Ljava/io/File;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getStream ()Ljava/io/InputStream;
 }
 
 public final class app/revanced/patcher/PatcherResult$PatchedResources {

--- a/src/main/kotlin/app/revanced/patcher/PatcherResult.kt
+++ b/src/main/kotlin/app/revanced/patcher/PatcherResult.kt
@@ -19,9 +19,9 @@ class PatcherResult internal constructor(
      * A dex file.
      *
      * @param name The original name of the dex file.
-     * @param stream The dex file as [InputStream].
+     * @param file The dex file as [File].
      */
-    class PatchedDexFile internal constructor(val name: String, val stream: InputStream)
+    class PatchedDexFile internal constructor(val name: String, val file: File)
 
     /**
      * The resources of a patched apk.

--- a/src/main/kotlin/app/revanced/patcher/patch/BytecodePatchContext.kt
+++ b/src/main/kotlin/app/revanced/patcher/patch/BytecodePatchContext.kt
@@ -152,7 +152,7 @@ class BytecodePatchContext internal constructor(private val config: PatcherConfi
                     DexIO.DEFAULT_MAX_DEX_POOL_SIZE,
                 ) { _, entryName, _ -> logger.info { "Compiled $entryName" } }
             }.listFiles(FileFilter { it.isFile })!!.map {
-                PatcherResult.PatchedDexFile(it.name, it.inputStream())
+                PatcherResult.PatchedDexFile(it.name, it)
             }.toSet()
 
         System.gc()


### PR DESCRIPTION
This should fix the issue where the CLI cannot purge the temporary patch files because there's still file handles from hanging input streams. 

I originally was going to just make `PatcherResult` implement `Closeable`, but I think it makes more sense to let Revanced library open and close the streams instead of passing them around.

https://github.com/ReVanced/revanced-cli/issues/327