### PR TITLE
perf: Use a buffered writer to reduce IO overhead

### DIFF
--- a/api/revanced-patcher.api
+++ b/api/revanced-patcher.api
@@ -171,9 +171,12 @@ public final class app/revanced/patcher/patch/BytecodePatchContext : app/revance
 public final class app/revanced/patcher/patch/Option {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/lang/String;ZLkotlin/reflect/KType;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefault ()Ljava/lang/Object;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getKey ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
 	public final fun getRequired ()Z
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun getType ()Lkotlin/reflect/KType;

--- a/src/main/kotlin/app/revanced/patcher/util/Document.kt
+++ b/src/main/kotlin/app/revanced/patcher/util/Document.kt
@@ -34,7 +34,7 @@ class Document internal constructor(
                 readerCount.remove(it)
             }
 
-            it.outputStream().use { stream ->
+            it.outputStream().buffered().use { stream ->
                 TransformerFactory.newInstance()
                     .newTransformer()
                     .transform(DOMSource(this), StreamResult(stream))


### PR DESCRIPTION
As ToSteam (used by XMLTransformer) writes char by char, using a buffered writer improves significantly the performance of the writing.

See #339 for the tests and the discussion